### PR TITLE
add path to collection detect callback

### DIFF
--- a/src/header.js
+++ b/src/header.js
@@ -14,7 +14,7 @@ export default class Header {
     }
     this._nodes = [];
     for (let i = 0; i < this._elements.length - 1; i++) {
-      const collection = detect.collection(this._elements[i]);
+      const collection = detect.collection(this._elements[i], alias);
       const name = collection.check ? collection.name : this._elements[i];
       const isCollection = collection.check;
       this._nodes.push({name, isCollection});

--- a/test/unit/treem.test.js
+++ b/test/unit/treem.test.js
@@ -309,6 +309,18 @@ describe('Treem', function() {
       expect(treem.data).to.deep.equal(expected);
     });
   });
+  describe('options: {detect: collection: <callback>}', function() {
+    it('should detect collection and transform them', function () {
+      const rows = [{a: 1, 'b.c': 2}, {a: 1, 'b.c': 3}];
+      const expected = [{a: 1, b: [{c: 2}, {c: 3}]}];
+      const treem = new Treem({detect: {collection: (node, path) => { return {
+        check: path === "b.c",
+        name: node
+      }}}});
+      treem.feed(rows);
+      expect(treem.data).to.deep.equal(expected);
+    });
+  });
   describe('options: {symbols: <object>}', function() {
     it('should use the provided symbols', function () {
       const rows = [{a: 1, '!b/*c': 2}, {a: 2, '!b/*c': 2}];


### PR DESCRIPTION
## Describe your changes
Enable a better collection detection based on the node full path and not only the node name.
No break changes because I just added a parameter to the callback without changing the existing one.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
